### PR TITLE
Refatoração de Curso para usar InstrutorNome em vez de InstrutorId

### DIFF
--- a/src/Peo.GestaoConteudo.Application/UseCases/Curso/Cadastrar/Command.cs
+++ b/src/Peo.GestaoConteudo.Application/UseCases/Curso/Cadastrar/Command.cs
@@ -12,7 +12,7 @@ public sealed record Command(
     string? Descricao,
 
     [Required]
-    Guid InstrutorId,
+    string InstrutorNome,
 
     string? ConteudoProgramatico,
 

--- a/src/Peo.GestaoConteudo.Application/UseCases/Curso/Cadastrar/Handler.cs
+++ b/src/Peo.GestaoConteudo.Application/UseCases/Curso/Cadastrar/Handler.cs
@@ -13,7 +13,7 @@ public class Handler(IRepository<Domain.Entities.Curso> repository) : IRequestHa
 
             titulo: request.Titulo,
             descricao: request.Descricao,
-            instrutorId: request.InstrutorId,
+            instrutorNome: request.InstrutorNome,
             conteudoProgramatico: new ConteudoProgramatico(request.ConteudoProgramatico),
             preco: request.Preco,
             estaPublicado: true,

--- a/src/Peo.GestaoConteudo.Domain/Entities/Curso.cs
+++ b/src/Peo.GestaoConteudo.Domain/Entities/Curso.cs
@@ -9,7 +9,7 @@ namespace Peo.GestaoConteudo.Domain.Entities
     {
         public string Titulo { get; private set; } = null!;
         public string? Descricao { get; private set; }
-        public Guid InstrutorId { get; private set; }
+        public string? InstrutorNome { get; private set; }
         public virtual ConteudoProgramatico? ConteudoProgramatico { get; private set; }
         public decimal Preco { get; private set; }
         public bool EstaPublicado { get; private set; }
@@ -21,11 +21,11 @@ namespace Peo.GestaoConteudo.Domain.Entities
         {
         }
 
-        public Curso(string titulo, string? descricao, Guid instrutorId, ConteudoProgramatico? conteudoProgramatico, decimal preco, bool estaPublicado, DateTime? dataPublicacao, List<string> tags, ICollection<Aula> aulas)
+        public Curso(string titulo, string? descricao, string instrutorNome, ConteudoProgramatico? conteudoProgramatico, decimal preco, bool estaPublicado, DateTime? dataPublicacao, List<string> tags, ICollection<Aula> aulas)
         {
             Titulo = titulo;
             Descricao = descricao;
-            InstrutorId = instrutorId;
+            InstrutorNome = instrutorNome;
             ConteudoProgramatico = conteudoProgramatico;
             Preco = preco;
             EstaPublicado = estaPublicado;

--- a/src/Peo.GestaoConteudo.Infra.Data/Migrations/20250826012455_CorrecaoCursoInstrutor.Designer.cs
+++ b/src/Peo.GestaoConteudo.Infra.Data/Migrations/20250826012455_CorrecaoCursoInstrutor.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Peo.GestaoConteudo.Infra.Data.Contexts;
 
@@ -10,9 +11,11 @@ using Peo.GestaoConteudo.Infra.Data.Contexts;
 namespace Peo.GestaoConteudo.Infra.Data.Migrations
 {
     [DbContext(typeof(GestaoConteudoContext))]
-    partial class GestaoConteudoContextModelSnapshot : ModelSnapshot
+    [Migration("20250826012455_CorrecaoCursoInstrutor")]
+    partial class CorrecaoCursoInstrutor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Peo.GestaoConteudo.Infra.Data/Migrations/20250826012455_CorrecaoCursoInstrutor.cs
+++ b/src/Peo.GestaoConteudo.Infra.Data/Migrations/20250826012455_CorrecaoCursoInstrutor.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Peo.GestaoConteudo.Infra.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CorrecaoCursoInstrutor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InstrutorId",
+                table: "Curso");
+
+            migrationBuilder.AddColumn<string>(
+                name: "InstrutorNome",
+                table: "Curso",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InstrutorNome",
+                table: "Curso");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "InstrutorId",
+                table: "Curso",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+    }
+}

--- a/src/Peo.GestaoConteudo.WebApi/Peo.GestaoConteudo.WebApi.csproj
+++ b/src/Peo.GestaoConteudo.WebApi/Peo.GestaoConteudo.WebApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>

--- a/src/Peo.Web.Bff/Services/GestaoConteudo/Dtos/CursoRequest.cs
+++ b/src/Peo.Web.Bff/Services/GestaoConteudo/Dtos/CursoRequest.cs
@@ -9,7 +9,7 @@ namespace Peo.Web.Bff.Services.GestaoConteudo.Dtos
         string? Descricao,
 
         [Required]
-        Guid InstrutorId,
+        string InstrutorNome,
 
         string? ConteudoProgramatico,
 

--- a/src/Peo.Web.Bff/openapi.json
+++ b/src/Peo.Web.Bff/openapi.json
@@ -725,9 +725,8 @@
             "type": "string",
             "nullable": true
           },
-          "instrutorId": {
-            "type": "string",
-            "format": "guid"
+          "instrutorNome": {
+            "type": "string"
           },
           "conteudoProgramatico": {
             "type": "string",

--- a/src/Peo.Web.Spa/Pages/Cursos/AdicionarCursos.razor
+++ b/src/Peo.Web.Spa/Pages/Cursos/AdicionarCursos.razor
@@ -1,0 +1,110 @@
+﻿@using MudBlazor
+@using System.ComponentModel.DataAnnotations
+@inject WebApiClient Api
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <TitleContent>Adicionar Curso</TitleContent>
+
+    <DialogContent>        
+        <EditForm EditContext="_editContext">
+            <DataAnnotationsValidator />
+            <MudStack Spacing="2">
+                <MudTextField @bind-Value="_model.Titulo" Label="Título" Required="true" />
+                <MudTextField @bind-Value="_model.InstrutorNome" Label="Instrutor" />
+                <MudTextField @bind-Value="_model.ConteudoProgramatico" Label="Conteúdo programático" Lines="4" />
+                <MudTextField @bind-Value="_tags" Label="Tags (separe por vírgula)" />
+                <MudTextField @bind-Value="_model.Descricao" Label="Descrição" Lines="3" />
+                <MudNumericField TValue="decimal" @bind-Value="_model.Preco" Label="Preço" Min="0" Required="true" />
+            </MudStack>
+        </EditForm>
+    </DialogContent>
+
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancelar</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                   OnClick="SaveClick" Disabled="@_busy">
+            @if (_busy)
+            {
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+            }
+            Salvar
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance? MudDialog { get; set; }
+
+    private bool _busy;
+    private string? _tags;
+    private readonly CursoForm _model = new();
+    private EditContext _editContext = default!;
+
+    protected override void OnInitialized()
+    {
+        _editContext = new EditContext(_model);
+    }
+
+    private async Task SaveClick()
+    {
+        if (!_editContext.Validate())
+            return;
+
+        await SaveAsync();
+    }
+
+    private async Task SaveAsync()
+    {
+        try
+        {
+            _busy = true;
+                        
+            var req = new CursoRequest
+            {
+                Titulo = _model.Titulo!,
+                Descricao = _model.Descricao,
+                Preco = _model.Preco,
+                InstrutorNome = _model.InstrutorNome,   
+                ConteudoProgramatico = _model.ConteudoProgramatico,
+                Tags = ParseTags(_tags)             
+            };
+
+            await Api.PostV1ConteudoCursoAsync(req, CancellationToken.None);
+
+            MudDialog?.Close(DialogResult.Ok(true));
+        }
+        catch (ApiException ex)
+        {
+            Snackbar.Add($"Erro ao salvar ({ex.StatusCode}): {ex.Message}", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Erro inesperado: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private void Cancel() => MudDialog?.Cancel();
+
+    private static List<string>? ParseTags(string? text) =>
+        string.IsNullOrWhiteSpace(text)
+            ? null
+            : text.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                  .Select(t => t.Trim())
+                  .Where(t => t.Length > 0)
+                  .Distinct(StringComparer.OrdinalIgnoreCase)
+                  .ToList();
+
+    private sealed class CursoForm
+    {
+        [Required, MinLength(2)] public string? Titulo { get; set; }
+        public string? InstrutorNome { get; set; }          
+        public string? ConteudoProgramatico { get; set; }   
+        public string? Descricao { get; set; }
+        [Range(0, double.MaxValue)] public decimal Preco { get; set; }
+    }
+}

--- a/src/Peo.Web.Spa/Pages/Cursos/AdicionarCursos.razor
+++ b/src/Peo.Web.Spa/Pages/Cursos/AdicionarCursos.razor
@@ -15,7 +15,7 @@
                 <MudTextField @bind-Value="_model.ConteudoProgramatico" Label="Conteúdo programático" Lines="4" />
                 <MudTextField @bind-Value="_tags" Label="Tags (separe por vírgula)" />
                 <MudTextField @bind-Value="_model.Descricao" Label="Descrição" Lines="3" />
-                <MudNumericField TValue="decimal" @bind-Value="_model.Preco" Label="Preço" Min="0" Required="true" />
+                <MudNumericField @bind-Value="_model.Preco" Label="Preço" Min="0" Required="true" />
             </MudStack>
         </EditForm>
     </DialogContent>

--- a/src/Peo.Web.Spa/Pages/Cursos/Cursos.razor
+++ b/src/Peo.Web.Spa/Pages/Cursos/Cursos.razor
@@ -5,7 +5,7 @@
 <PageTitle>Cursos</PageTitle>
 
 <MudText Typo="Typo.h1" Class="mb-4" Align="Align.Center">Gestão de Cursos</MudText>
-<MudDataGrid T="CursoResponse" Items="_cursosLista">
+<MudDataGrid T="Curso" Items="_cursosLista">
     <ToolBarContent>
         <MudText Typo="Typo.h6">Lista de Cursos</MudText>
         <MudSpacer />
@@ -13,10 +13,18 @@
             Adicionar 
         </MudButton>
     </ToolBarContent>
-    <Columns>
-        <PropertyColumn Property="i => i.Id" Title="ID" />
+    <Columns>        
+        <HierarchyColumn T="Curso" />
         <PropertyColumn Property="i => i.Titulo" Title="Título" />
+        <PropertyColumn Property="i => i.NomeInstrutor" Title="Instrutor" />
         <PropertyColumn Property="i => i.Descricao" Title="Descrição do Curso" />
         <PropertyColumn Property="i => i.Preco" Title="Preço" />
     </Columns>
+    <ChildRowContent>
+        <MudPaper Class="p-4" Style="white-space:pre-wrap">
+            <MudText Typo="Typo.h6">Conteúdo programático</MudText>
+            <MudDivider Class="my-2" />
+            @context.Item.ConteudoProgramatico.Conteudo
+        </MudPaper>
+    </ChildRowContent>
 </MudDataGrid>

--- a/src/Peo.Web.Spa/Services/WebApiClient.cs
+++ b/src/Peo.Web.Spa/Services/WebApiClient.cs
@@ -1816,8 +1816,8 @@ namespace Peo.Web.Spa.Services
         [System.Text.Json.Serialization.JsonPropertyName("descricao")]
         public string Descricao { get; set; }
 
-        [System.Text.Json.Serialization.JsonPropertyName("instrutorId")]
-        public System.Guid InstrutorId { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("instrutorNome")]
+        public string InstrutorNome { get; set; }
 
         [System.Text.Json.Serialization.JsonPropertyName("conteudoProgramatico")]
         public string ConteudoProgramatico { get; set; }

--- a/tests/Peo.Tests.UnitTests/GestaoConteudo/Aula/CadastrarAulaCommandHandlerTests.cs
+++ b/tests/Peo.Tests.UnitTests/GestaoConteudo/Aula/CadastrarAulaCommandHandlerTests.cs
@@ -25,7 +25,7 @@ public class CadastrarAulaCommandHandlerTests
         var curso = new Peo.GestaoConteudo.Domain.Entities.Curso(
             titulo: "Curso Teste",
             descricao: "Descrição Teste",
-            instrutorId: Guid.CreateVersion7(),
+            instrutorNome: "Nome instrutor teste",
             conteudoProgramatico: new ConteudoProgramatico("Conteúdo Programático Teste"),
             preco: 99.99m,
             estaPublicado: true,

--- a/tests/Peo.Tests.UnitTests/GestaoConteudo/Aula/GetAllQueryHandlerTests.cs
+++ b/tests/Peo.Tests.UnitTests/GestaoConteudo/Aula/GetAllQueryHandlerTests.cs
@@ -47,7 +47,7 @@ public class ObterTodasAulasQueryHandlerTests
         var curso = new Peo.GestaoConteudo.Domain.Entities.Curso(
             titulo: "Curso Teste",
             descricao: "Descrição Teste",
-            instrutorId: Guid.CreateVersion7(),
+            instrutorNome: "Nome Instrutor Teste",
             conteudoProgramatico: new ConteudoProgramatico("Conteúdo Programático Teste"),
             preco: 99.99m,
             estaPublicado: true,
@@ -100,7 +100,7 @@ public class ObterTodasAulasQueryHandlerTests
         var curso = new Peo.GestaoConteudo.Domain.Entities.Curso(
             titulo: "Curso Teste",
             descricao: "Descrição Teste",
-            instrutorId: Guid.CreateVersion7(),
+            instrutorNome: "Nome Instrutor Teste",
             conteudoProgramatico: new ConteudoProgramatico("Conteúdo Programático Teste"),
             preco: 99.99m,
             estaPublicado: true,

--- a/tests/Peo.Tests.UnitTests/GestaoConteudo/Curso/CadastrarCursoCommandHandlerTests.cs
+++ b/tests/Peo.Tests.UnitTests/GestaoConteudo/Curso/CadastrarCursoCommandHandlerTests.cs
@@ -23,7 +23,7 @@ public class CadastrarCursoCommandHandlerTests
         var comando = new Command(
             Titulo: "Curso Teste",
             Descricao: "Descrição Teste",
-            InstrutorId: Guid.CreateVersion7(),
+            InstrutorNome: "Nome Instrutor Teste",
             ConteudoProgramatico: "Conteúdo Programático Teste",
             Preco: 99.99m,
             Tags: ["teste", "curso"]
@@ -43,7 +43,7 @@ public class CadastrarCursoCommandHandlerTests
         _repositorioMock.Verify(x => x.Insert(It.Is<Peo.GestaoConteudo.Domain.Entities.Curso>(c =>
             c.Titulo == comando.Titulo &&
             c.Descricao == comando.Descricao &&
-            c.InstrutorId == comando.InstrutorId &&
+            c.InstrutorNome == comando.InstrutorNome &&
             c.ConteudoProgramatico!.Conteudo == comando.ConteudoProgramatico &&
             c.Preco == comando.Preco &&
             c.Tags.SequenceEqual(comando.Tags!)

--- a/tests/Peo.Tests.UnitTests/GestaoConteudo/Curso/ObterCursoPorIdQueryHandlerTests.cs
+++ b/tests/Peo.Tests.UnitTests/GestaoConteudo/Curso/ObterCursoPorIdQueryHandlerTests.cs
@@ -27,7 +27,7 @@ public class ObterCursoPorIdQueryHandlerTests
         var curso = new Peo.GestaoConteudo.Domain.Entities.Curso(
             titulo: "Curso Teste",
             descricao: "Descrição Teste",
-            instrutorId: Guid.CreateVersion7(),
+            instrutorNome: "Nome Instrutor Teste",
             conteudoProgramatico: new ConteudoProgramatico("Conteúdo Programático Teste"),
             preco: 99.99m,
             estaPublicado: true,

--- a/tests/Peo.Tests.UnitTests/GestaoConteudo/Curso/ObterTodosCursosQueryHandlerTests.cs
+++ b/tests/Peo.Tests.UnitTests/GestaoConteudo/Curso/ObterTodosCursosQueryHandlerTests.cs
@@ -28,7 +28,7 @@ public class ObterTodosCursosQueryHandlerTests
             new(
                 titulo: "Curso Teste 1",
                 descricao: "Descrição Teste 1",
-                instrutorId: Guid.CreateVersion7(),
+                instrutorNome: "Nome Instrutor Teste",
                 conteudoProgramatico: new ConteudoProgramatico("Conteúdo Programático Teste 1"),
                 preco: 99.99m,
                 estaPublicado: true,
@@ -39,7 +39,7 @@ public class ObterTodosCursosQueryHandlerTests
             new(
                 titulo: "Curso Teste 2",
                 descricao: "Descrição Teste 2",
-                instrutorId: Guid.CreateVersion7(),
+                instrutorNome:"Nome Instrutor Teste",
                 conteudoProgramatico: new ConteudoProgramatico("Conteúdo Programático Teste 2"),
                 preco: 199.99m,
                 estaPublicado: true,


### PR DESCRIPTION
Substitui a propriedade 'InstrutorId' por 'InstrutorNome' em todo o domínio, aplicação, DTOs, migrações e testes. Atualiza o esquema do banco de dados e todos os usos relacionados para armazenar e manipular o nome do instrutor em vez de um GUID. Também adiciona uma nova página para adicionar cursos e melhora a listagem de cursos na SPA.